### PR TITLE
removing double '\n' when number entry is invalid

### DIFF
--- a/telnum.py
+++ b/telnum.py
@@ -53,7 +53,7 @@ def number_to_text(num):
             return '%s\n%s, %s - %s' % (number, desc, country, numtype)
 
     except:
-        return '%s\ninvalid' % (num)
+        return '%sinvalid' % (num)
 
 def main():
     if len(sys.argv) > 1:

--- a/telnum.py
+++ b/telnum.py
@@ -13,6 +13,8 @@ def number_to_text(num):
     try:
         if not num.startswith('+'):
             num = '+' + num
+        if not num.endswith('\n'):  # last line
+            num = num + '\n'
 
         x = phonenumbers.parse(num)
 


### PR DESCRIPTION
num already has a line break as last character